### PR TITLE
Fix build with default LDFLAGS in pacman>=6.1.0

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -54,7 +54,7 @@ build() {
   # See https://bugs.archlinux.org/task/55102 / https://bugs.archlinux.org/task/54845
   export CFLAGS=${CFLAGS/-fno-plt}
   export CXXFLAGS=${CXXFLAGS/-fno-plt}
-  export LDFLAGS=${LDFLAGS/,-z,now}
+  export LDFLAGS=${LDFLAGS/-Wl,-z,now}
 
   arch-meson "${_pkgbase}" build \
     -D ipv6=true \


### PR DESCRIPTION
The update from `pacman-6.0.2` to `pacman-6.1.0` changed the `makepkg.conf` default from

```
LDFLAGS="-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now"
```

to

```
LDFLAGS="-Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now \
         -Wl,-z,pack-relative-relocs"
```

We modify the `LDFLAGS` prior to running Meson via

```
export LDFLAGS=${LDFLAGS/,-z,now}
```

While this was fine before, it will now result in a lone `-Wl` not followed by a comma.